### PR TITLE
add:teamapiの登録、編集、削除、一覧取得を作成

### DIFF
--- a/api/src/cruds/teams.py
+++ b/api/src/cruds/teams.py
@@ -1,0 +1,29 @@
+from fastapi import APIRouter,Depends,status,HTTPException
+from src.schemas.schemas import Team,CreateTeam
+from sqlalchemy.orm import Session
+import models
+from database import get_db
+
+def create_team(request:Team,db:Session):
+    new_team = models.Team(team_name =request.team_name)
+    db.add(new_team)
+    db.commit()
+    db.refresh(new_team)
+    return new_team
+
+def show_team(db:Session):
+    teams = db.query(models.Team).all()
+    return teams
+
+def delete_team(id:int,db:Session):
+    team = db.query(models.Team).filter(models.Team.id ==id)
+    if not team.first():
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,detail=f'{id} Blog with the is not found')
+    team.delete(synchronize_session=False)
+    db.commit()
+    return 'Deletion competed'
+
+def update_team(id:int,request:Team,db:Session):
+    teams = db.query(models.Team).filter(models.Team.id ==id).update(request.dict())
+    db.commit()
+    return 'Deletion competed'

--- a/api/src/routes/team.py
+++ b/api/src/routes/team.py
@@ -1,32 +1,24 @@
 from fastapi import APIRouter,Depends,status
-from src.schemas.schemas import Team,ShowTeam
+from src.schemas.schemas import Team,CreateTeam
 from sqlalchemy.orm import Session
 import models
 from database import get_db
+from src.cruds import teams
 
 router = APIRouter()
 
 @router.get("/api/teams",status_code=status.HTTP_200_OK,tags=['teams'])
 def get_team_all(db:Session=Depends(get_db)):
-    new_team = db.query(models.Team).all()
-    return new_team
+    return teams.show_team(db)
 
 @router.post("/api/teams/",status_code=status.HTTP_201_CREATED,tags=['teams'])
-def create_team(team:Team,db:Session=Depends(get_db)):
-    new_team = models.Team(id =team.id,team_name =team.team_name)
-    db.add(new_team)
-    db.commit()
-    db.refresh(new_team)
-    return  new_team
+def create_team(request:CreateTeam,db:Session=Depends(get_db)):
+    return teams.create_team(request,db)
 
 @router.put("/api/teams/{id}",status_code=status.HTTP_202_ACCEPTED,tags=['teams'])
-def update_team(id:int,request:ShowTeam,db:Session=Depends(get_db)):
-    db.query(models.Team).filter(models.Team.id ==id).update(request.dict())
-    db.commit()
-    return 'Update complete'
+def update_team(id:int,request:CreateTeam,db:Session=Depends(get_db)):
+    return teams.update_team(id,request,db)
 
 @router.delete("/api/teams/{id}",status_code=status.HTTP_204_NO_CONTENT,tags=['teams'])
 def delete_team(id:int,db:Session=Depends(get_db)):
-    db.query(models.Team).filter(models.Team.id ==id).delete(synchronize_session=False)
-    db.commit()
-    return "Deletion competed"
+    return teams.delete_team(id,db)

--- a/api/src/schemas/schemas.py
+++ b/api/src/schemas/schemas.py
@@ -16,7 +16,7 @@ class Team(BaseModel):
     id :int
     team_name:str
 
-class ShowTeam(BaseModel):
+class CreateTeam(BaseModel):
     team_name:str
 
 class Product(BaseModel):


### PR DESCRIPTION
**実装目的**
teamを登録、編集、削除、一覧取得できるようにする。

**URL**
http://localhost:8080/docs#

**試行方法**
①post
上記URLのteamsタグの中のPOSTで下記画像右側のTry it out 押下
![スクリーンショット 2023-06-30 14 04 18](https://github.com/SATOKOKI645/waiwai/assets/113570839/72452f5b-2759-4253-999b-e0dd73c9e4c2)
"team_name":"string"のstringの値を任意のチーム名を記載後、Excuteを押下
![スクリーンショット 2023-06-30 14 04 26](https://github.com/SATOKOKI645/waiwai/assets/113570839/0435c483-66d5-4e0a-a79c-7a2e77243d82)
responseで下記画像の通り201が返ってくる。
![スクリーンショット 2023-06-30 14 11 46](https://github.com/SATOKOKI645/waiwai/assets/113570839/fffe3653-fcc0-461f-80c6-9fdfb83da34b)

②get
上記URLのteamsタグの中のGETで右側のTry it out 押下
Excuteを押下
responseで200が返ってくるかつ下記画像の通りpostで登録したチームが返ってくる。
![スクリーンショット 2023-06-30 14 16 45](https://github.com/SATOKOKI645/waiwai/assets/113570839/b71f0dae-802d-475e-8ede-6097428ec9ee)


③DELETE
上記URLのteamsタグの中のDELETEで右側のTry it out 押下
削除したidを入力後Excuteを押下
responseで204が返ってくる。その後GETをもう一度行い登録のあったチームの削除が行われているか確認する。

④PUT
上記URLのteamsタグの中のPUTで右側のTry it out 押下
削除したidを入力後Excuteを押下
"team_name":"string"のstringの値を変更後のチーム名を記載後、Excuteを押下
responseで202が返ってくる。その後GETをもう一度行い登録のあったチームの編集が行われているか確認する。

備考
質問があればヤマザキまで